### PR TITLE
Class 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "class",
     "family": "arale",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "keywords": ["infrastructure"],
     "description": "提供简洁的 OO 实现。",
     "homepage": "http://aralejs.org/class/",

--- a/src/class.js
+++ b/src/class.js
@@ -15,11 +15,11 @@ define(function(require, exports, module) {
   function Class(o) {
     // Convert existed function to Class.
     if (!(this instanceof Class) && isFunction(o)) {
-      return classify(o)
+      return classify(o);
     }
   }
 
-  module.exports = Class
+  module.exports = Class;
 
 
   // Create a new Class.
@@ -37,48 +37,48 @@ define(function(require, exports, module) {
   //
   Class.create = function(parent, properties) {
     if (!isFunction(parent)) {
-      properties = parent
-      parent = null
+      properties = parent;
+      parent = null;
     }
 
-    properties || (properties = {})
-    parent || (parent = properties.Extends || Class)
-    properties.Extends = parent
+    properties || (properties = {});
+    parent || (parent = properties.Extends || Class);
+    properties.Extends = parent;
 
     // The created class constructor
     function SubClass() {
       // Call the parent constructor.
-      parent.apply(this, arguments)
+      parent.apply(this, arguments);
 
       // Only call initialize in self constructor.
       if (this.constructor === SubClass && this.initialize) {
-        this.initialize.apply(this, arguments)
+        this.initialize.apply(this, arguments);
       }
     }
 
     // Inherit class (static) properties from parent.
     if (parent !== Class) {
-      mix(SubClass, parent, parent.StaticsWhiteList)
+      mix(SubClass, parent, parent.StaticsWhiteList);
     }
 
     // Add instance properties to the subclass.
-    implement.call(SubClass, properties)
+    implement.call(SubClass, properties);
 
     // Make subclass extendable.
-    return classify(SubClass)
-  }
+    return classify(SubClass);
+  };
 
 
   function implement(properties) {
-    var key, value
+    var key, value;
 
     for (key in properties) {
-      value = properties[key]
+      value = properties[key];
 
       if (Class.Mutators.hasOwnProperty(key)) {
-        Class.Mutators[key].call(this, value)
+        Class.Mutators[key].call(this, value);
       } else {
-        this.prototype[key] = value
+        this.prototype[key] = value;
       }
     }
   }
@@ -86,17 +86,17 @@ define(function(require, exports, module) {
 
   // Create a sub Class based on `Class`.
   Class.extend = function(properties) {
-    properties || (properties = {})
-    properties.Extends = this
+    properties || (properties = {});
+    properties.Extends = this;
 
-    return Class.create(properties)
-  }
+    return Class.create(properties);
+  };
 
 
   function classify(cls) {
-    cls.extend = Class.extend
-    cls.implement = implement
-    return cls
+    cls.extend = Class.extend;
+    cls.implement = implement;
+    return cls;
   }
 
 
@@ -104,36 +104,36 @@ define(function(require, exports, module) {
   Class.Mutators = {
 
     'Extends': function(parent) {
-      var existed = this.prototype
-      var proto = createProto(parent.prototype)
+      var existed = this.prototype;
+      var proto = createProto(parent.prototype);
 
       // Keep existed properties.
-      mix(proto, existed)
+      mix(proto, existed);
 
       // Enforce the constructor to be what we expect.
-      proto.constructor = this
+      proto.constructor = this;
 
       // Set the prototype chain to inherit from `parent`.
-      this.prototype = proto
+      this.prototype = proto;
 
       // Set a convenience property in case the parent's prototype is
       // needed later.
-      this.superclass = parent.prototype
+      this.superclass = parent.prototype;
     },
 
     'Implements': function(items) {
-      isArray(items) || (items = [items])
-      var proto = this.prototype, item
+      isArray(items) || (items = [items]);
+      var proto = this.prototype, item;
 
       while (item = items.shift()) {
-        mix(proto, item.prototype || item)
+        mix(proto, item.prototype || item);
       }
     },
 
     'Statics': function(staticProperties) {
-      mix(this, staticProperties)
+      mix(this, staticProperties);
     }
-  }
+  };
 
 
   // Shared empty constructor function to aid in prototype-chain creation.
@@ -141,14 +141,14 @@ define(function(require, exports, module) {
   }
 
   // See: http://jsperf.com/object-create-vs-new-ctor
-  var createProto = Object.__proto__ ?
-      function(proto) {
-        return { __proto__: proto }
-      } :
-      function(proto) {
-        Ctor.prototype = proto
-        return new Ctor()
-      }
+  var createProto = Object['__proto__'] ?
+    function(proto) {
+      return { '__proto__': proto };
+    } :
+    function(proto) {
+      Ctor.prototype = proto;
+      return new Ctor();
+    };
 
 
   // Helpers
@@ -158,37 +158,37 @@ define(function(require, exports, module) {
     // Copy "all" properties including inherited ones.
     for (var p in s) {
       if (s.hasOwnProperty(p)) {
-        if (wl && indexOf(wl, p) === -1) continue
+        if (wl && indexOf(wl, p) === -1) continue;
 
         // 在 iPhone 1 代等设备的 Safari 中，prototype 也会被枚举出来，需排除
         if (p !== 'prototype') {
-          r[p] = s[p]
+          r[p] = s[p];
         }
       }
     }
   }
 
 
-  var toString = Object.prototype.toString
+  var toString = Object.prototype.toString;
 
   var isArray = Array.isArray || function(val) {
-      return toString.call(val) === '[object Array]'
-  }
+    return toString.call(val) === '[object Array]';
+  };
 
   var isFunction = function(val) {
-    return toString.call(val) === '[object Function]'
-  }
+    return toString.call(val) === '[object Function]';
+  };
 
   var indexOf = Array.prototype.indexOf ?
-      function(arr, item) {
-        return arr.indexOf(item)
-      } :
-      function(arr, item) {
-        for (var i = 0, len = arr.length; i < len; i++) {
-          if (arr[i] === item) {
-            return i
-          }
+    function(arr, item) {
+      return arr.indexOf(item);
+    } :
+    function(arr, item) {
+      for (var i = 0, len = arr.length; i < len; i++) {
+        if (arr[i] === item) {
+          return i;
         }
-        return -1
       }
-})
+      return -1;
+    };
+});

--- a/tests/class-spec.js
+++ b/tests/class-spec.js
@@ -7,23 +7,6 @@ define(function(require) {
 
     describe('.create', function() {
 
-      it('Class.create(parent)', function() {
-        function Animal(name) {
-          this.name = name;
-        }
-
-        Animal.prototype.getName = function() {
-          return this.name;
-        };
-
-        var Dog = Class.create(Animal);
-        var dog = new Dog('Jack');
-
-        expect(dog.constructor).to.equal(Dog);
-        expect(dog.name).to.equal('Jack');
-        expect(dog.getName()).to.equal('Jack');
-      });
-
       it('Class.create(null)', function() {
         var Dog = Class.create(null);
         var dog = new Dog();
@@ -31,20 +14,21 @@ define(function(require) {
         expect(Dog.superclass.constructor).to.equal(Class);
 
         Dog = Class.create();
-        new Dog();
+        dog = new Dog();
+        expect(dog.constructor).to.equal(Dog);
         expect(Dog.superclass.constructor).to.equal(Class);
       });
 
-      it('Class.create(parent, properties)', function() {
-        function Animal(name) {
-          this.name = name;
-        }
+      it('Class.create(properties)', function() {
+        var Dog = Class.create({
+          initialize: function(name) {
+            this.name = name;
+          },
 
-        Animal.prototype.getName = function() {
-          return this.name;
-        };
+          getName: function() {
+            return this.name;
+          },
 
-        var Dog = Class.create(Animal, {
           talk: function() {
             return 'I am ' + this.name;
           }
@@ -55,6 +39,27 @@ define(function(require) {
         expect(dog.talk()).to.equal('I am Jack');
       });
 
+      it('Class.create(function)', function() {
+        var counter = 0;
+        function Animal() {
+          counter++;
+        }
+
+        Animal.prototype.talk = function() {
+          return 'wangwang';
+        };
+
+        var Dog = Class.create(Animal);
+        var dog = new Dog();
+
+        // not call the function
+        expect(counter).to.equal(0);
+        expect(dog.talk()).to.equal('wangwang');
+      });
+    });
+
+    describe('.extend', function() {
+
       it('call initialize method properly', function() {
         var counter = 0;
 
@@ -64,20 +69,18 @@ define(function(require) {
           }
         });
 
-        var Dog = Class.create(Animal, {
+        var Dog = Animal.extend({
           initialize: function() {
             counter++;
           }
         });
-
         new Dog();
 
         // Dog 有 initialize 时，只调用 Dog 的 initialize;
         expect(counter).to.equal(1);
 
         counter = 0;
-        Dog = Class.create(Animal);
-
+        Dog = Animal.extend();
         new Dog();
 
         // Dog 没有 initialize 时，会自动调用父类中最近的 initialize;
@@ -93,8 +96,7 @@ define(function(require) {
         });
 
         var Bird = Animal.extend({
-          fly: function() {
-          }
+          fly: function() {}
         });
 
         var bird = new Bird('Frank', 'Wang');
@@ -114,7 +116,7 @@ define(function(require) {
           }
         });
 
-        var Dog = Class.create(Animal, {
+        var Dog = Animal.extend({
           initialize: function() {
             Dog.superclass.initialize();
           },
@@ -129,29 +131,6 @@ define(function(require) {
         expect(dog.talk()).to.equal('I am an animal');
       });
 
-      it('Extends', function() {
-        function Animal(name) {
-          this.name = name;
-        }
-
-        Animal.prototype.getName = function() {
-          return this.name;
-        };
-
-        var Dog = Class.create({
-          Extends: Animal,
-          talk: function() {
-            return 'I am ' + this.name;
-          }
-        });
-
-        var dog = new Dog('Jack');
-
-        expect(dog.name).to.equal('Jack');
-        expect(dog.getName()).to.equal('Jack');
-        expect(dog.talk()).to.equal('I am Jack');
-      });
-
       it('new AnotherClass() in initialize', function() {
         var called = [];
 
@@ -161,13 +140,13 @@ define(function(require) {
           }
         });
 
-        var Pig = Class.create(Animal, {
+        var Pig = Animal.extend({
           initialize: function() {
             called.push('Pig');
           }
         });
 
-        var Dog = Class.create(Animal, {
+        var Dog = Animal.extend({
           initialize: function() {
             new Pig();
             called.push('Dog');
@@ -178,53 +157,12 @@ define(function(require) {
         expect(called.join(' ')).to.equal('Pig Dog');
 
       });
-    });
-
-    describe('.extend', function() {
-
-      it('statics inherited from parent', function() {
-        var Animal = Class.create();
-        Animal.LEGS = 4;
-
-        var Dog = Class.create({
-          Extends: Animal,
-
-          Statics: {
-            COLOR: 'red'
-          },
-
-          initialize: function(name) {
-            this.name = name;
-          }
-        });
-
-        expect(Dog.LEGS).to.equal(4);
-        expect(Dog.COLOR).to.equal('red');
-
-        var Pig = Class.create(Class);
-
-        expect(typeof Pig.implement).to.equal('function');
-        expect(typeof Pig.extend).to.equal('function');
-        expect(typeof Pig.Mutators).to.equal('undefined');
-        expect(typeof Pig.create).to.equal('undefined');
-      });
-
-      it('Class.extend', function() {
-        var Dog = Class.extend({
-          initialize: function(name) {
-            this.name = name;
-          }
-        });
-
-        var dog = new Dog('Jack');
-
-        expect(dog.name).to.equal('Jack');
-        expect(Dog.superclass.constructor).to.equal(Class);
-      });
 
       it('SubClass.extend', function() {
-        var Animal = Class.create(function(name) {
-          this.name = name;
+        var Animal = Class.create({
+          initialize: function(name) {
+            this.name = name;
+          }
         });
 
         var Dog = Animal.extend();
@@ -237,15 +175,16 @@ define(function(require) {
     });
 
     describe('.implement', function() {
+      it('.implement(null)', function() {
+        var Animal = Class.create();
+        Animal.implement(null);
+      });
 
-      it('Implements', function() {
-        var Animal = Class.create(function(name) {
-          this.name = name;
-        }, {
-          getName: function() {
-            return this.name;
+      it('.implement will return this', function() {
+        var Animal = Class.create({
+          initialize: function(name) {
+            this.name = name;
           }
-
         });
 
         var Flyable = {
@@ -254,16 +193,47 @@ define(function(require) {
           }
         };
 
-        var Talkable = function() {
+        var Talkable = {
+          talk: function() {
+            return 'I am ' + this.name;
+          }
         };
+
+        Animal
+          .implement(Flyable)
+          .implement(Talkable);
+
+        var animal = new Animal('Jack');
+
+        expect(animal.name).to.equal('Jack');
+        expect(animal.fly()).to.equal('I am flying');
+        expect(animal.talk()).to.equal('I am Jack');
+      });
+
+      it('.implement([prop1, prop2])', function() {
+        var Animal = Class.create({
+          initialize: function(name) {
+            this.name = name;
+          },
+          getName: function() {
+            return this.name;
+          }
+        });
+
+        var Flyable = {
+          fly: function() {
+            return 'I am flying';
+          }
+        };
+
+        var Talkable = function() {};
         Talkable.prototype.talk = function() {
           return 'I am ' + this.name;
         };
 
-        var Dog = Class.create({
-          Extends: Animal,
-          Implements: [Flyable, Talkable]
-        });
+        var Dog = Animal
+          .extend()
+          .implement([Flyable, Talkable]);
 
         var dog = new Dog('Jack');
 
@@ -273,9 +243,11 @@ define(function(require) {
         expect(dog.talk()).to.equal('I am Jack');
       });
       
-      it('SubClass.implement', function() {
-        var Animal = Class.create(function(name) {
-          this.name = name;
+      it('.implement(properties)', function() {
+        var Animal = Class.create({
+          initialize: function(name) {
+            this.name = name;
+          }
         });
 
         var Dog = Animal.extend();
@@ -294,7 +266,46 @@ define(function(require) {
 
     });
 
+    describe('static', function() {
+      it('statics inherited from parent', function() {
+        var Animal = Class.create();
+        Animal.LEGS = 4;
+
+        var Dog = Animal.extend({
+          initialize: function(name) {
+            this.name = name;
+          }
+        });
+
+        expect(Dog.LEGS).to.equal(4);
+
+        var Pig = Class.create(Class);
+
+        expect(typeof Pig.implement).to.equal('function');
+        expect(typeof Pig.extend).to.equal('function');
+        expect(typeof Pig.Mutators).to.equal('undefined');
+        expect(typeof Pig.create).to.equal('undefined');
+      });
+    });
+
     describe('convert', function() {
+
+      it('convert function to Class', function() {
+        function Animal(name) {
+          this.name = name;
+        }
+
+        Animal.prototype.getName = function() {
+          return this.name;
+        };
+
+        var Dog = Class(Animal);
+        var dog = new Dog('Jack');
+
+        expect(dog.constructor).to.equal(Dog);
+        expect(dog.name).to.equal('Jack');
+        expect(dog.getName()).to.equal('Jack');
+      });
 
       it('convert existed function to Class', function() {
         function Dog(name) {
@@ -323,45 +334,6 @@ define(function(require) {
         expect(myDog.name).to.equal('Frank');
       });
 
-    });
-
-    it('Statics', function() {
-      var Dog = Class.create({
-        initialize: function(name) {
-          this.name = name;
-        },
-        Statics: {
-          COLOR: 'red'
-        }
-      });
-
-      var dog = new Dog('Jack');
-
-      expect(dog.name).to.equal('Jack');
-      expect(Dog.COLOR).to.equal('red');
-    });
-
-    it('StaticsWhiteList', function() {
-
-      var A = Class.create();
-      A.a = 1;
-      A.b = 1;
-      A.StaticsWhiteList = ['a'];
-      var B = A.extend(A);
-
-      expect(B.a).to.equal(1);
-      expect(B.b).to.equal(undefined);
-      expect(B.StaticsWhiteList).to.equal(undefined);
-
-    });
-
-    it('Meta information', function() {
-
-      var Dog = require('./data/dog');
-      var dog = new Dog();
-
-      expect(dog.isAnimal).to.equal(true);
-      expect(dog.isDog).to.equal(true);
     });
 
   });

--- a/tests/class-spec.js
+++ b/tests/class-spec.js
@@ -1,208 +1,208 @@
 define(function(require) {
-  var Class = require('class')
-  var expect = require('expect')
+  var Class = require('class');
+  var expect = require('expect');
 
   describe('Class', function() {
 
     it('Class.create(parent)', function() {
       function Animal(name) {
-        this.name = name
+        this.name = name;
       }
 
       Animal.prototype.getName = function() {
-        return this.name
-      }
+        return this.name;
+      };
 
-      var Dog = Class.create(Animal)
-      var dog = new Dog('Jack')
+      var Dog = Class.create(Animal);
+      var dog = new Dog('Jack');
 
-      expect(dog.constructor).to.equal(Dog)
-      expect(dog.name).to.equal('Jack')
-      expect(dog.getName()).to.equal('Jack')
-    })
+      expect(dog.constructor).to.equal(Dog);
+      expect(dog.name).to.equal('Jack');
+      expect(dog.getName()).to.equal('Jack');
+    });
 
     it('Class.create(null)', function() {
-      var Dog = Class.create(null)
-      var dog = new Dog()
-      expect(dog.constructor).to.equal(Dog)
-      expect(Dog.superclass.constructor).to.equal(Class)
+      var Dog = Class.create(null);
+      var dog = new Dog();
+      expect(dog.constructor).to.equal(Dog);
+      expect(Dog.superclass.constructor).to.equal(Class);
 
-      Dog = Class.create()
-      new Dog()
-      expect(Dog.superclass.constructor).to.equal(Class)
-    })
+      Dog = Class.create();
+      new Dog();
+      expect(Dog.superclass.constructor).to.equal(Class);
+    });
 
     it('Class.create(parent, properties)', function() {
       function Animal(name) {
-        this.name = name
+        this.name = name;
       }
 
       Animal.prototype.getName = function() {
-        return this.name
-      }
+        return this.name;
+      };
 
       var Dog = Class.create(Animal, {
         talk: function() {
-          return 'I am ' + this.name
+          return 'I am ' + this.name;
         }
-      })
-      var dog = new Dog('Jack')
+      });
+      var dog = new Dog('Jack');
 
-      expect(dog.name).to.equal('Jack')
-      expect(dog.talk()).to.equal('I am Jack')
-    })
+      expect(dog.name).to.equal('Jack');
+      expect(dog.talk()).to.equal('I am Jack');
+    });
 
     it('call initialize method properly', function() {
-      var counter = 0
+      var counter = 0;
 
       var Animal = Class.create({
         initialize: function() {
-          counter++
+          counter++;
         }
-      })
+      });
 
       var Dog = Class.create(Animal, {
         initialize: function() {
-          counter++
+          counter++;
         }
-      })
+      });
 
-      new Dog()
+      new Dog();
 
-      // Dog 有 initialize 时，只调用 Dog 的 initialize
-      expect(counter).to.equal(1)
+      // Dog 有 initialize 时，只调用 Dog 的 initialize;
+      expect(counter).to.equal(1);
 
-      counter = 0
-      Dog = Class.create(Animal)
+      counter = 0;
+      Dog = Class.create(Animal);
 
-      new Dog()
+      new Dog();
 
-      // Dog 没有 initialize 时，会自动调用父类中最近的 initialize
-      expect(counter).to.equal(1)
-    })
+      // Dog 没有 initialize 时，会自动调用父类中最近的 initialize;
+      expect(counter).to.equal(1);
+    });
 
     it('pass arguments to initialize method properly', function() {
 
       var Animal = Class.create({
         initialize: function(firstName, lastName) {
-          this.fullName = firstName + ' ' + lastName
+          this.fullName = firstName + ' ' + lastName;
         }
-      })
+      });
 
       var Bird = Animal.extend({
         fly: function() {
         }
-      })
+      });
 
-      var bird = new Bird('Frank', 'Wang')
+      var bird = new Bird('Frank', 'Wang');
 
-      expect(bird.fullName).to.equal('Frank Wang')
-    })
+      expect(bird.fullName).to.equal('Frank Wang');
+    });
 
     it('superclass', function() {
-      var counter = 0
+      var counter = 0;
 
       var Animal = Class.create({
         initialize: function() {
-          counter++
+          counter++;
         },
         talk: function() {
-          return 'I am an animal'
+          return 'I am an animal';
         }
-      })
+      });
 
       var Dog = Class.create(Animal, {
         initialize: function() {
-          Dog.superclass.initialize()
+          Dog.superclass.initialize();
         },
         talk: function() {
-          return Dog.superclass.talk()
+          return Dog.superclass.talk();
         }
-      })
+      });
 
-      var dog = new Dog()
+      var dog = new Dog();
 
-      expect(counter).to.equal(1)
-      expect(dog.talk()).to.equal('I am an animal')
-    })
+      expect(counter).to.equal(1);
+      expect(dog.talk()).to.equal('I am an animal');
+    });
 
     it('Extends', function() {
       function Animal(name) {
-        this.name = name
+        this.name = name;
       }
 
       Animal.prototype.getName = function() {
-        return this.name
-      }
+        return this.name;
+      };
 
       var Dog = Class.create({
         Extends: Animal,
         talk: function() {
-          return 'I am ' + this.name
+          return 'I am ' + this.name;
         }
-      })
+      });
 
-      var dog = new Dog('Jack')
+      var dog = new Dog('Jack');
 
-      expect(dog.name).to.equal('Jack')
-      expect(dog.getName()).to.equal('Jack')
-      expect(dog.talk()).to.equal('I am Jack')
-    })
+      expect(dog.name).to.equal('Jack');
+      expect(dog.getName()).to.equal('Jack');
+      expect(dog.talk()).to.equal('I am Jack');
+    });
 
     it('Implements', function() {
       var Animal = Class.create(function(name) {
-        this.name = name
+        this.name = name;
       }, {
         getName: function() {
-          return this.name
+          return this.name;
         }
 
-      })
+      });
 
       var Flyable = {
         fly: function() {
-          return 'I am flying'
+          return 'I am flying';
         }
-      }
+      };
 
       var Talkable = function() {
-      }
+      };
       Talkable.prototype.talk = function() {
-        return 'I am ' + this.name
-      }
+        return 'I am ' + this.name;
+      };
 
       var Dog = Class.create({
         Extends: Animal,
         Implements: [Flyable, Talkable]
-      })
+      });
 
-      var dog = new Dog('Jack')
+      var dog = new Dog('Jack');
 
-      expect(dog.name).to.equal('Jack')
-      expect(dog.getName()).to.equal('Jack')
-      expect(dog.fly()).to.equal('I am flying')
-      expect(dog.talk()).to.equal('I am Jack')
-    })
+      expect(dog.name).to.equal('Jack');
+      expect(dog.getName()).to.equal('Jack');
+      expect(dog.fly()).to.equal('I am flying');
+      expect(dog.talk()).to.equal('I am Jack');
+    });
 
     it('Statics', function() {
       var Dog = Class.create({
         initialize: function(name) {
-          this.name = name
+          this.name = name;
         },
         Statics: {
           COLOR: 'red'
         }
-      })
+      });
 
-      var dog = new Dog('Jack')
+      var dog = new Dog('Jack');
 
-      expect(dog.name).to.equal('Jack')
-      expect(Dog.COLOR).to.equal('red')
-    })
+      expect(dog.name).to.equal('Jack');
+      expect(Dog.COLOR).to.equal('red');
+    });
 
     it('statics inherited from parent', function() {
-      var Animal = Class.create()
-      Animal.LEGS = 4
+      var Animal = Class.create();
+      Animal.LEGS = 4;
 
       var Dog = Class.create({
         Extends: Animal,
@@ -212,142 +212,141 @@ define(function(require) {
         },
 
         initialize: function(name) {
-          this.name = name
+          this.name = name;
         }
-      })
+      });
 
-      expect(Dog.LEGS).to.equal(4)
-      expect(Dog.COLOR).to.equal('red')
+      expect(Dog.LEGS).to.equal(4);
+      expect(Dog.COLOR).to.equal('red');
 
-      var Pig = Class.create(Class)
+      var Pig = Class.create(Class);
 
-      expect(typeof Pig.implement).to.equal('function')
-      expect(typeof Pig.extend).to.equal('function')
-      expect(typeof Pig.Mutators).to.equal('undefined')
-      expect(typeof Pig.create).to.equal('undefined')
-    })
+      expect(typeof Pig.implement).to.equal('function');
+      expect(typeof Pig.extend).to.equal('function');
+      expect(typeof Pig.Mutators).to.equal('undefined');
+      expect(typeof Pig.create).to.equal('undefined');
+    });
 
     it('Class.extend', function() {
       var Dog = Class.extend({
         initialize: function(name) {
-          this.name = name
+          this.name = name;
         }
-      })
+      });
 
-      var dog = new Dog('Jack')
+      var dog = new Dog('Jack');
 
-      expect(dog.name).to.equal('Jack')
-      expect(Dog.superclass.constructor).to.equal(Class)
-    })
+      expect(dog.name).to.equal('Jack');
+      expect(Dog.superclass.constructor).to.equal(Class);
+    });
 
     it('SubClass.extend', function() {
       var Animal = Class.create(function(name) {
-        this.name = name
-      })
+        this.name = name;
+      });
 
-      var Dog = Animal.extend()
-      var dog = new Dog('Jack')
+      var Dog = Animal.extend();
+      var dog = new Dog('Jack');
 
-      expect(dog.name).to.equal('Jack')
-      expect(Dog.superclass.constructor).to.equal(Animal)
-    })
+      expect(dog.name).to.equal('Jack');
+      expect(Dog.superclass.constructor).to.equal(Animal);
+    });
 
     it('SubClass.implement', function() {
       var Animal = Class.create(function(name) {
-        this.name = name
-      })
+        this.name = name;
+      });
 
-      var Dog = Animal.extend()
+      var Dog = Animal.extend();
       Dog.implement({
         talk: function() {
-          return 'I am ' + this.name
+          return 'I am ' + this.name;
         }
-      })
+      });
 
-      var dog = new Dog('Jack')
+      var dog = new Dog('Jack');
 
-      expect(dog.name).to.equal('Jack')
-      expect(dog.talk()).to.equal('I am Jack')
-      expect(Dog.superclass.constructor).to.equal(Animal)
-    })
+      expect(dog.name).to.equal('Jack');
+      expect(dog.talk()).to.equal('I am Jack');
+      expect(Dog.superclass.constructor).to.equal(Animal);
+    });
 
     it('convert existed function to Class', function() {
       function Dog(name) {
-        this.name = name
+        this.name = name;
       }
 
       Class(Dog).implement({
         getName: function() {
-          return this.name
+          return this.name;
         }
-      })
+      });
 
-      var dog = new Dog('Jack')
+      var dog = new Dog('Jack');
 
-      expect(dog.name).to.equal('Jack')
-      expect(dog.getName()).to.equal('Jack')
+      expect(dog.name).to.equal('Jack');
+      expect(dog.getName()).to.equal('Jack');
 
       var MyDog = Dog.extend({
         talk: function() {
-          return 'I am ' + this.name
+          return 'I am ' + this.name;
         }
-      })
+      });
 
-      var myDog = new MyDog('Frank')
-      expect(myDog.name).to.equal('Frank')
-    })
+      var myDog = new MyDog('Frank');
+      expect(myDog.name).to.equal('Frank');
+    });
 
     it('new AnotherClass() in initialize', function() {
-      var called = []
+      var called = [];
 
       var Animal = Class.create({
         initialize: function() {
-          called.push('Animal')
+          called.push('Animal');
         }
-      })
+      });
 
       var Pig = Class.create(Animal, {
         initialize: function() {
-          called.push('Pig')
+          called.push('Pig');
         }
-      })
+      });
 
       var Dog = Class.create(Animal, {
         initialize: function() {
-          new Pig()
-          called.push('Dog')
+          new Pig();
+          called.push('Dog');
         }
-      })
+      });
 
-      new Dog()
-      expect(called.join(' ')).to.equal('Pig Dog')
+      new Dog();
+      expect(called.join(' ')).to.equal('Pig Dog');
 
-    })
+    });
 
     it('StaticsWhiteList', function() {
 
-      var A = Class.create()
-      A.a = 1
-      A.b = 1
-      A.StaticsWhiteList = ['a']
-      var B = A.extend(A)
+      var A = Class.create();
+      A.a = 1;
+      A.b = 1;
+      A.StaticsWhiteList = ['a'];
+      var B = A.extend(A);
 
-      expect(B.a).to.equal(1)
-      expect(B.b).to.equal(undefined)
-      expect(B.StaticsWhiteList).to.equal(undefined)
+      expect(B.a).to.equal(1);
+      expect(B.b).to.equal(undefined);
+      expect(B.StaticsWhiteList).to.equal(undefined);
 
-    })
+    });
 
     it('Meta information', function() {
 
-      var Dog = require('./data/dog')
-      var dog = new Dog()
-      seajs.log(dog, 'dir')
+      var Dog = require('./data/dog');
+      var dog = new Dog();
 
-      expect(dog.isAnimal).to.equal(true)
-      expect(dog.isDog).to.equal(true)
-    })
+      expect(dog.isAnimal).to.equal(true);
+      expect(dog.isDog).to.equal(true);
+    });
 
-  })
+  });
 
-})
+});

--- a/tests/class-spec.js
+++ b/tests/class-spec.js
@@ -1,187 +1,328 @@
+/* jshint newcap: false */
 define(function(require) {
   var Class = require('class');
   var expect = require('expect');
 
   describe('Class', function() {
 
-    it('Class.create(parent)', function() {
-      function Animal(name) {
-        this.name = name;
-      }
+    describe('.create', function() {
 
-      Animal.prototype.getName = function() {
-        return this.name;
-      };
-
-      var Dog = Class.create(Animal);
-      var dog = new Dog('Jack');
-
-      expect(dog.constructor).to.equal(Dog);
-      expect(dog.name).to.equal('Jack');
-      expect(dog.getName()).to.equal('Jack');
-    });
-
-    it('Class.create(null)', function() {
-      var Dog = Class.create(null);
-      var dog = new Dog();
-      expect(dog.constructor).to.equal(Dog);
-      expect(Dog.superclass.constructor).to.equal(Class);
-
-      Dog = Class.create();
-      new Dog();
-      expect(Dog.superclass.constructor).to.equal(Class);
-    });
-
-    it('Class.create(parent, properties)', function() {
-      function Animal(name) {
-        this.name = name;
-      }
-
-      Animal.prototype.getName = function() {
-        return this.name;
-      };
-
-      var Dog = Class.create(Animal, {
-        talk: function() {
-          return 'I am ' + this.name;
+      it('Class.create(parent)', function() {
+        function Animal(name) {
+          this.name = name;
         }
-      });
-      var dog = new Dog('Jack');
 
-      expect(dog.name).to.equal('Jack');
-      expect(dog.talk()).to.equal('I am Jack');
-    });
-
-    it('call initialize method properly', function() {
-      var counter = 0;
-
-      var Animal = Class.create({
-        initialize: function() {
-          counter++;
-        }
-      });
-
-      var Dog = Class.create(Animal, {
-        initialize: function() {
-          counter++;
-        }
-      });
-
-      new Dog();
-
-      // Dog 有 initialize 时，只调用 Dog 的 initialize;
-      expect(counter).to.equal(1);
-
-      counter = 0;
-      Dog = Class.create(Animal);
-
-      new Dog();
-
-      // Dog 没有 initialize 时，会自动调用父类中最近的 initialize;
-      expect(counter).to.equal(1);
-    });
-
-    it('pass arguments to initialize method properly', function() {
-
-      var Animal = Class.create({
-        initialize: function(firstName, lastName) {
-          this.fullName = firstName + ' ' + lastName;
-        }
-      });
-
-      var Bird = Animal.extend({
-        fly: function() {
-        }
-      });
-
-      var bird = new Bird('Frank', 'Wang');
-
-      expect(bird.fullName).to.equal('Frank Wang');
-    });
-
-    it('superclass', function() {
-      var counter = 0;
-
-      var Animal = Class.create({
-        initialize: function() {
-          counter++;
-        },
-        talk: function() {
-          return 'I am an animal';
-        }
-      });
-
-      var Dog = Class.create(Animal, {
-        initialize: function() {
-          Dog.superclass.initialize();
-        },
-        talk: function() {
-          return Dog.superclass.talk();
-        }
-      });
-
-      var dog = new Dog();
-
-      expect(counter).to.equal(1);
-      expect(dog.talk()).to.equal('I am an animal');
-    });
-
-    it('Extends', function() {
-      function Animal(name) {
-        this.name = name;
-      }
-
-      Animal.prototype.getName = function() {
-        return this.name;
-      };
-
-      var Dog = Class.create({
-        Extends: Animal,
-        talk: function() {
-          return 'I am ' + this.name;
-        }
-      });
-
-      var dog = new Dog('Jack');
-
-      expect(dog.name).to.equal('Jack');
-      expect(dog.getName()).to.equal('Jack');
-      expect(dog.talk()).to.equal('I am Jack');
-    });
-
-    it('Implements', function() {
-      var Animal = Class.create(function(name) {
-        this.name = name;
-      }, {
-        getName: function() {
+        Animal.prototype.getName = function() {
           return this.name;
-        }
+        };
 
+        var Dog = Class.create(Animal);
+        var dog = new Dog('Jack');
+
+        expect(dog.constructor).to.equal(Dog);
+        expect(dog.name).to.equal('Jack');
+        expect(dog.getName()).to.equal('Jack');
       });
 
-      var Flyable = {
-        fly: function() {
-          return 'I am flying';
-        }
-      };
+      it('Class.create(null)', function() {
+        var Dog = Class.create(null);
+        var dog = new Dog();
+        expect(dog.constructor).to.equal(Dog);
+        expect(Dog.superclass.constructor).to.equal(Class);
 
-      var Talkable = function() {
-      };
-      Talkable.prototype.talk = function() {
-        return 'I am ' + this.name;
-      };
-
-      var Dog = Class.create({
-        Extends: Animal,
-        Implements: [Flyable, Talkable]
+        Dog = Class.create();
+        new Dog();
+        expect(Dog.superclass.constructor).to.equal(Class);
       });
 
-      var dog = new Dog('Jack');
+      it('Class.create(parent, properties)', function() {
+        function Animal(name) {
+          this.name = name;
+        }
 
-      expect(dog.name).to.equal('Jack');
-      expect(dog.getName()).to.equal('Jack');
-      expect(dog.fly()).to.equal('I am flying');
-      expect(dog.talk()).to.equal('I am Jack');
+        Animal.prototype.getName = function() {
+          return this.name;
+        };
+
+        var Dog = Class.create(Animal, {
+          talk: function() {
+            return 'I am ' + this.name;
+          }
+        });
+        var dog = new Dog('Jack');
+
+        expect(dog.name).to.equal('Jack');
+        expect(dog.talk()).to.equal('I am Jack');
+      });
+
+      it('call initialize method properly', function() {
+        var counter = 0;
+
+        var Animal = Class.create({
+          initialize: function() {
+            counter++;
+          }
+        });
+
+        var Dog = Class.create(Animal, {
+          initialize: function() {
+            counter++;
+          }
+        });
+
+        new Dog();
+
+        // Dog 有 initialize 时，只调用 Dog 的 initialize;
+        expect(counter).to.equal(1);
+
+        counter = 0;
+        Dog = Class.create(Animal);
+
+        new Dog();
+
+        // Dog 没有 initialize 时，会自动调用父类中最近的 initialize;
+        expect(counter).to.equal(1);
+      });
+
+      it('pass arguments to initialize method properly', function() {
+
+        var Animal = Class.create({
+          initialize: function(firstName, lastName) {
+            this.fullName = firstName + ' ' + lastName;
+          }
+        });
+
+        var Bird = Animal.extend({
+          fly: function() {
+          }
+        });
+
+        var bird = new Bird('Frank', 'Wang');
+
+        expect(bird.fullName).to.equal('Frank Wang');
+      });
+
+      it('superclass', function() {
+        var counter = 0;
+
+        var Animal = Class.create({
+          initialize: function() {
+            counter++;
+          },
+          talk: function() {
+            return 'I am an animal';
+          }
+        });
+
+        var Dog = Class.create(Animal, {
+          initialize: function() {
+            Dog.superclass.initialize();
+          },
+          talk: function() {
+            return Dog.superclass.talk();
+          }
+        });
+
+        var dog = new Dog();
+
+        expect(counter).to.equal(1);
+        expect(dog.talk()).to.equal('I am an animal');
+      });
+
+      it('Extends', function() {
+        function Animal(name) {
+          this.name = name;
+        }
+
+        Animal.prototype.getName = function() {
+          return this.name;
+        };
+
+        var Dog = Class.create({
+          Extends: Animal,
+          talk: function() {
+            return 'I am ' + this.name;
+          }
+        });
+
+        var dog = new Dog('Jack');
+
+        expect(dog.name).to.equal('Jack');
+        expect(dog.getName()).to.equal('Jack');
+        expect(dog.talk()).to.equal('I am Jack');
+      });
+
+      it('new AnotherClass() in initialize', function() {
+        var called = [];
+
+        var Animal = Class.create({
+          initialize: function() {
+            called.push('Animal');
+          }
+        });
+
+        var Pig = Class.create(Animal, {
+          initialize: function() {
+            called.push('Pig');
+          }
+        });
+
+        var Dog = Class.create(Animal, {
+          initialize: function() {
+            new Pig();
+            called.push('Dog');
+          }
+        });
+
+        new Dog();
+        expect(called.join(' ')).to.equal('Pig Dog');
+
+      });
+    });
+
+    describe('.extend', function() {
+
+      it('statics inherited from parent', function() {
+        var Animal = Class.create();
+        Animal.LEGS = 4;
+
+        var Dog = Class.create({
+          Extends: Animal,
+
+          Statics: {
+            COLOR: 'red'
+          },
+
+          initialize: function(name) {
+            this.name = name;
+          }
+        });
+
+        expect(Dog.LEGS).to.equal(4);
+        expect(Dog.COLOR).to.equal('red');
+
+        var Pig = Class.create(Class);
+
+        expect(typeof Pig.implement).to.equal('function');
+        expect(typeof Pig.extend).to.equal('function');
+        expect(typeof Pig.Mutators).to.equal('undefined');
+        expect(typeof Pig.create).to.equal('undefined');
+      });
+
+      it('Class.extend', function() {
+        var Dog = Class.extend({
+          initialize: function(name) {
+            this.name = name;
+          }
+        });
+
+        var dog = new Dog('Jack');
+
+        expect(dog.name).to.equal('Jack');
+        expect(Dog.superclass.constructor).to.equal(Class);
+      });
+
+      it('SubClass.extend', function() {
+        var Animal = Class.create(function(name) {
+          this.name = name;
+        });
+
+        var Dog = Animal.extend();
+        var dog = new Dog('Jack');
+
+        expect(dog.name).to.equal('Jack');
+        expect(Dog.superclass.constructor).to.equal(Animal);
+      });
+
+    });
+
+    describe('.implement', function() {
+
+      it('Implements', function() {
+        var Animal = Class.create(function(name) {
+          this.name = name;
+        }, {
+          getName: function() {
+            return this.name;
+          }
+
+        });
+
+        var Flyable = {
+          fly: function() {
+            return 'I am flying';
+          }
+        };
+
+        var Talkable = function() {
+        };
+        Talkable.prototype.talk = function() {
+          return 'I am ' + this.name;
+        };
+
+        var Dog = Class.create({
+          Extends: Animal,
+          Implements: [Flyable, Talkable]
+        });
+
+        var dog = new Dog('Jack');
+
+        expect(dog.name).to.equal('Jack');
+        expect(dog.getName()).to.equal('Jack');
+        expect(dog.fly()).to.equal('I am flying');
+        expect(dog.talk()).to.equal('I am Jack');
+      });
+      
+      it('SubClass.implement', function() {
+        var Animal = Class.create(function(name) {
+          this.name = name;
+        });
+
+        var Dog = Animal.extend();
+        Dog.implement({
+          talk: function() {
+            return 'I am ' + this.name;
+          }
+        });
+
+        var dog = new Dog('Jack');
+
+        expect(dog.name).to.equal('Jack');
+        expect(dog.talk()).to.equal('I am Jack');
+        expect(Dog.superclass.constructor).to.equal(Animal);
+      });
+
+    });
+
+    describe('convert', function() {
+
+      it('convert existed function to Class', function() {
+        function Dog(name) {
+          this.name = name;
+        }
+
+
+        Class(Dog).implement({
+          getName: function() {
+            return this.name;
+          }
+        });
+
+        var dog = new Dog('Jack');
+
+        expect(dog.name).to.equal('Jack');
+        expect(dog.getName()).to.equal('Jack');
+
+        var MyDog = Dog.extend({
+          talk: function() {
+            return 'I am ' + this.name;
+          }
+        });
+
+        var myDog = new MyDog('Frank');
+        expect(myDog.name).to.equal('Frank');
+      });
+
     });
 
     it('Statics', function() {
@@ -198,130 +339,6 @@ define(function(require) {
 
       expect(dog.name).to.equal('Jack');
       expect(Dog.COLOR).to.equal('red');
-    });
-
-    it('statics inherited from parent', function() {
-      var Animal = Class.create();
-      Animal.LEGS = 4;
-
-      var Dog = Class.create({
-        Extends: Animal,
-
-        Statics: {
-          COLOR: 'red'
-        },
-
-        initialize: function(name) {
-          this.name = name;
-        }
-      });
-
-      expect(Dog.LEGS).to.equal(4);
-      expect(Dog.COLOR).to.equal('red');
-
-      var Pig = Class.create(Class);
-
-      expect(typeof Pig.implement).to.equal('function');
-      expect(typeof Pig.extend).to.equal('function');
-      expect(typeof Pig.Mutators).to.equal('undefined');
-      expect(typeof Pig.create).to.equal('undefined');
-    });
-
-    it('Class.extend', function() {
-      var Dog = Class.extend({
-        initialize: function(name) {
-          this.name = name;
-        }
-      });
-
-      var dog = new Dog('Jack');
-
-      expect(dog.name).to.equal('Jack');
-      expect(Dog.superclass.constructor).to.equal(Class);
-    });
-
-    it('SubClass.extend', function() {
-      var Animal = Class.create(function(name) {
-        this.name = name;
-      });
-
-      var Dog = Animal.extend();
-      var dog = new Dog('Jack');
-
-      expect(dog.name).to.equal('Jack');
-      expect(Dog.superclass.constructor).to.equal(Animal);
-    });
-
-    it('SubClass.implement', function() {
-      var Animal = Class.create(function(name) {
-        this.name = name;
-      });
-
-      var Dog = Animal.extend();
-      Dog.implement({
-        talk: function() {
-          return 'I am ' + this.name;
-        }
-      });
-
-      var dog = new Dog('Jack');
-
-      expect(dog.name).to.equal('Jack');
-      expect(dog.talk()).to.equal('I am Jack');
-      expect(Dog.superclass.constructor).to.equal(Animal);
-    });
-
-    it('convert existed function to Class', function() {
-      function Dog(name) {
-        this.name = name;
-      }
-
-      Class(Dog).implement({
-        getName: function() {
-          return this.name;
-        }
-      });
-
-      var dog = new Dog('Jack');
-
-      expect(dog.name).to.equal('Jack');
-      expect(dog.getName()).to.equal('Jack');
-
-      var MyDog = Dog.extend({
-        talk: function() {
-          return 'I am ' + this.name;
-        }
-      });
-
-      var myDog = new MyDog('Frank');
-      expect(myDog.name).to.equal('Frank');
-    });
-
-    it('new AnotherClass() in initialize', function() {
-      var called = [];
-
-      var Animal = Class.create({
-        initialize: function() {
-          called.push('Animal');
-        }
-      });
-
-      var Pig = Class.create(Animal, {
-        initialize: function() {
-          called.push('Pig');
-        }
-      });
-
-      var Dog = Class.create(Animal, {
-        initialize: function() {
-          new Pig();
-          called.push('Dog');
-        }
-      });
-
-      new Dog();
-      expect(called.join(' ')).to.equal('Pig Dog');
-
     });
 
     it('StaticsWhiteList', function() {

--- a/tests/data/animal.js
+++ b/tests/data/animal.js
@@ -1,9 +1,9 @@
 define(function(require, exports, module) {
 
-  var Class = require('class')
+  var Class = require('class');
 
   module.exports = Class.create({
     isAnimal: true
-  })
+  });
 
-})
+});

--- a/tests/data/animal.js
+++ b/tests/data/animal.js
@@ -1,9 +1,0 @@
-define(function(require, exports, module) {
-
-  var Class = require('class');
-
-  module.exports = Class.create({
-    isAnimal: true
-  });
-
-});

--- a/tests/data/dog.js
+++ b/tests/data/dog.js
@@ -1,9 +1,9 @@
 define(function(require) {
 
-  var Animal = require('./animal')
+  var Animal = require('./animal');
 
   return Animal.extend({
     isDog: true
-  })
+  });
 
-})
+});

--- a/tests/data/dog.js
+++ b/tests/data/dog.js
@@ -1,9 +1,0 @@
-define(function(require) {
-
-  var Animal = require('./animal');
-
-  return Animal.extend({
-    isDog: true
-  });
-
-});


### PR DESCRIPTION
class@1.2.0 和 class@2.0.0 会调整一些接口，class@2.0.0 还会去除兼容性代码。
## 不要 merge
## 现有 API
### 创建

创建一个 Class， **常用**

```
var Base = Class.create({
  initialize: function () {}
});
```

创建一个 Class，继承一个原生的 function

```
function Base() {}
Base.prototype.initialize = function() {}
Class.create(Base, {
  initialize: function () {}
});
```
### 继承

通过 extend 来继承， **常用**

```
var Base = Class.create({
  initialize: function () {}
});
Base.extend({
  initialize: function () {}
});
```

通过 create 来继承

```
var Base = Class.create({
  initialize: function () {}
});
var Widget = Class.create(Base, {
  initialize: function () {}
});
```

通过 Extends 来继承

```
var Base = Class.create({
  initialize: function () {}
});
var Widget = Class.create({
  Extends: Base,
  initialize: function () {}
});
```
### 混入

使用 Implements 混入， **常用**

```
var Base = Class.create({
  Implements: Mixins,
  initialize: function () {}
});
```

使用 implement 混入

```
var Base = Class.create({
  initialize: function () {}
});
Base.implement(Mixins);
```
### 其他功能

转换

```
function Base() {}
Base.prototype.initialize = function() {}
Class(Base);
```

静态方法 Statics，不写示例了
## 整理 API

class 主要有创建，继承和混入的功能，但从上面 api 来看每种都有两种以上的可选项，但有些并不常用。
- 创建只保留 Class.create(properties)
- 继承和混入只支持 implement 和 extend，去除 Implements 和 Extends
- 去除 Statics
- 去除 StaticsWhiteList

Implements 虽然常用，但是为了 API 保持一致，我觉得方法调用优于属性。
## 格式
- 加分号 ！！！
- 通过 jshint
